### PR TITLE
fix(visual): complete rendering events, reset font size, fix title layout

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,6 +1,6 @@
 # Agent-oriented Copilot instructions for PR checks
 
-**Purpose.** Keep only the checks and guidance that an automated coding agent (Copilot-style) can perform reliably during a PR review for a Power BI custom visual repository. Interactive/manual steps live in `HUMAN-certification-checklist.md`.
+**Purpose.** Keep only the checks and guidance that an automated coding agent (Copilot-style) can perform reliably during a PR review for a Power BI custom visual repository. Interactive/manual certification steps are out of scope and left to human reviewers.
 
 **Context.** This repository contains a Microsoft custom visual for Power BI. All contributions must follow Microsoft coding standards and Power BI custom visual guidelines. The agent prioritizes checks that enforce those standards and flags deviations for human review.
 
@@ -9,14 +9,14 @@
 ## Summary of agent-capable checks (categories)
 
 - **PR metadata**: non-empty description; conventional commit title.
-- **Manifests & capabilities (Power BI)**: presence & schema sanity of `capabilities.json`, `pbiviz.json`, `package.json`, `tsconfig.json`, `src/visual.ts`; no `WebAccess`; version bump rules.
+- **Manifests & capabilities (Power BI)**: presence & schema sanity of `capabilities.json`, `pbiviz.json`, `package.json`, `tsconfig.json`, `src/visual.ts`; no `WebAccess`; backward-compatible capabilities structure; version bump rules.
 - **Security & forbidden patterns**: unsafe DOM, dynamic scripts, timers-with-strings, `eval/new Function`, network APIs, unsafe bindings.
 - **Secrets scanning**: common tokens/keys; urgent human review.
 - **Build artifacts & minification & assets**: `.min.*` in `src/`, overly large or minified-looking files.
 - **Linting, tests, CI**: scripts present; ESLint config; CI status present if `src/**` changed.
 - **Dependencies**: lockfile updated on dependency change; major version bumps flagged.
 - **Tests & localization**: unit tests reminder on logic changes; `stringResources/en-US/**` coverage; spellcheck.
-- **Documentation & changelog**: `changelog.md` on non-trivial changes; usage examples for public APIs.
+- **Documentation & changelog**: `CHANGELOG.md` on non-trivial changes; usage examples for public APIs.
 - **Code quality & architecture**: scope summary, performance & accessibility hints, state/event cleanup, error handling, maintainability notes.
 - **Reporting**: one-line summary counts; per-finding snippets; suggested fixes; auto-labels.
 
@@ -32,10 +32,13 @@
 - **Capabilities**:
   - No `WebAccess` or privileges that permit arbitrary network calls → `error`.
   - `dataRoles` and `dataViewMappings` must be present → `error`.
+  - **Backward-compatible structure**: do not rename, remove, or change the nesting of existing `objects.*` or their `properties.*`. Saved settings in existing reports are keyed by `objectName.propertyName`, so restructuring silently breaks them → renames/removals/re-nesting → `error`. Only additive changes (new objects/properties) are allowed.
+  - Formatting-model note: converting a `SimpleCard` to a `CompositeCard` (UI grouping) is safe **only if** the card `name` (= capabilities object name) and each slice `name` (= property name) stay unchanged — group names are UI-only and are not persisted.
 - **`pbiviz.json`**:
-  - `visual.version` must bump for functional changes (semver).  
-  - `visual.guid`, `visual.displayName`, `author`, `supportUrl`, `apiVersion` present.  
-  - `apiVersion` compatible with `@types/powerbi-visuals-api` (major alignment) → mismatch → `warning`.
+  - `visual.version` uses the 4-segment Power BI format `major.minor.patch.build` and must bump for functional changes.
+  - `visual.guid`, `visual.displayName`, `author`, `supportUrl`, `apiVersion` present.
+  - `apiVersion` compatible with the installed `powerbi-visuals-api` (major alignment) → mismatch → `warning`.
+- **Version bump must be applied consistently** across all of: `pbiviz.json` (`visual.version`), `package.json` (`version`), `package-lock.json` (root `version` and the root `packages.""` entry — regenerated via `npm install`), and a new `CHANGELOG.md` section. Any of these out of sync → `warning`.
 
 ### 2) Security & forbidden patterns (report file:line)
 - Unsafe DOM:
@@ -72,6 +75,7 @@
 ### 5) Linting, tests
 - `package.json` scripts must include:
   - `lint`, `test`, `package` (or `pbiviz package`) → missing → `warning`.
+  - CI (`.github/workflows/build.yml`) runs `npm run lint`, `npm run package`, and `npm test`.
 - ESLint configuration must exist at repo root:
   - Prefer `eslint.config.mjs`; if `.eslintrc.*` or `.eslintignore` or `eslintConfig` in `package.json` -> ask to migrate to `eslint.config.mjs`.
   - Missing → `warning` + suggest basic config for Power BI visuals.
@@ -89,10 +93,10 @@
   - Missing localization keys → `warning`.
 - Spellcheck (en-US as source):
   - Report probable typos with level (`info`/`warning`) and replacement suggestion.
-  - Exclude identifiers/acronyms/brand-names based on `.spellcheck-whitelist`.
+  - Exclude identifiers/acronyms/brand-names (maintain a `.spellcheck-whitelist` at repo root if false positives recur).
 
 ### 8) Documentation & changelog
-- For non-trivial changes — update `changelog.md` → `info`/`warning`.
+- For non-trivial changes — update `CHANGELOG.md` → `info`/`warning`.
 - For new public APIs — add usage examples → `info`.
 
 ### 9) Code quality & architecture (senior review mindset)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,27 +9,32 @@ on:
   pull_request:
     branches: [ main, dev, certification ]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
 
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
 
     strategy:
       matrix:
-        node-version: [18.x, 20.x]
+        node-version: [20.x, 22.x]
 
     steps:
-    - uses: actions/checkout@v2
-    - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v1
+    - uses: actions/checkout@v4
+    - name: Setup Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v4
       with:
         node-version: ${{ matrix.node-version }}
+        cache: 'npm'
     - run: npm ci
     - run: npm audit
       continue-on-error: true
     - run: npm outdated
       continue-on-error: true
-    - run: npm run eslint
+    - run: npm run lint
     - run: npm run package
     - run: npm test
       env:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        language: ['typescript']
+        language: ['javascript-typescript']
  
     steps:
     - name: Checkout repository
@@ -29,10 +29,11 @@ jobs:
       with:
         fetch-depth: 2
 
-    - name: Use Node.js 18
-      uses: actions/setup-node@v2
+    - name: Setup Node.js 20
+      uses: actions/setup-node@v4
       with:
-        node-version: 18.x
+        node-version: 20.x
+        cache: 'npm'
 
     - name: Install Dependencies
       run: npm ci

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+## 2.2.3
+### Fixes
+* Fixed rendering events not being completed when the visual has no data (could break export to PDF/PowerPoint and image rendering)
+* Fixed title and value font size not resetting when switching back to "Auto text size"
+* Fixed KPI values being truncated with an ellipsis; only the title is shortened when it doesn't fit
+* Fixed the chart title overlapping the date range label
+
+### Maintenance
+* Updated GitHub Actions workflows and copilot-instructions
+
+
 ## 2.2.2
 ### Visual changes
 * Changed default font from helvetica to Segoe UI

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@microsoft/dualkpi",
-  "version": "2.2.2.0",
+  "version": "2.2.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@microsoft/dualkpi",
-      "version": "2.2.2.0",
+      "version": "2.2.3.0",
       "license": "MIT",
       "dependencies": {
         "d3-array": "^3.2.4",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@microsoft/dualkpi",
   "displayName": "Dual KPI",
-  "version": "2.2.2.0",
+  "version": "2.2.3.0",
   "private": true,
   "description": "Dual KPI efficiently visualizes two measures over time. It shows their trend based on a joint timeline, while absolute values may use different scales, for example Profit and Market share or Sales and Profit. Each KPI can be visualized as line chart or area chart. The visual has dynamic behavior and can show historical value and the change from the latest value when you hover over it. It also has small icons and labels to convey KPI definitions and alerts about data freshness. Customize colors, titles, axis properties, tooltips, and more, to create visually appealing and functional executive dashboards.",
   "author": {
@@ -20,7 +20,7 @@
     "pbiviz": "pbiviz",
     "start": "pbiviz start",
     "package": "pbiviz package",
-    "eslint": "npx eslint .",
+    "lint": "npx eslint .",
     "test": "karma start",
     "cert": "pbiviz --install-cert"
   },

--- a/pbiviz.json
+++ b/pbiviz.json
@@ -1,10 +1,10 @@
 {
   "visual": {
     "name": "dualKpi",
-    "displayName": "Dual KPI 2.2.2.0",
+    "displayName": "Dual KPI",
     "guid": "PBI_CV_3C80B1F2_09AF_4123_8E99_C3CBC46B23E0",
     "visualClassName": "DualKpi",
-    "version": "2.2.2.0",
+    "version": "2.2.3.0",
     "description": "Dual KPI efficiently visualizes two measures over time. It shows their trend based on a joint timeline, while absolute values may use different scales, for example Profit and Market share or Sales and Profit. Each KPI can be visualized as line chart or area chart. The visual has dynamic behavior and can show historical value and the change from the latest value when you hover over it. It also has small icons and labels to convey KPI definitions and alerts about data freshness. Customize colors, titles, axis properties, tooltips, and more, to create visually appealing and functional executive dashboards.",
     "supportUrl": "http://community.powerbi.com",
     "gitHubUrl": "https://github.com/Microsoft/powerbi-visuals-dualkpi"

--- a/src/visual.ts
+++ b/src/visual.ts
@@ -203,7 +203,7 @@ export class DualKpi implements IVisual {
     private target: HTMLElement;
     private size: DualKpiSize;
     private sizeCssClass: DualKpiSizeClass;
-    private eventService: IVisualEventService
+    private eventService: IVisualEventService;
 
     private svgRoot: d3Selection<SVGSVGElement, unknown, null, undefined>;
 
@@ -239,6 +239,7 @@ export class DualKpi implements IVisual {
 
     private static INVISIBLE: string = "invisible";
     private static readonly VISUAL_BORDER_AREA_PADDING_RATIO = 0.9;
+    private static readonly BOTTOM_TITLE_GAP: number = 8;
 
     private static OPACITY_MIN: number = 0;
     private static OPACITY_MAX: number = 100;
@@ -266,7 +267,7 @@ export class DualKpi implements IVisual {
 
     private init(options: VisualConstructorOptions): void {
         this.target = options.element;
-        this.eventService = options.host.eventService
+        this.eventService = options.host.eventService;
         this.size = DualKpiSize.small;
         this.sizeCssClass = "small";
         this.valueFormatter = d3Format(".3s");
@@ -488,12 +489,14 @@ export class DualKpi implements IVisual {
     }
 
     public update(options: VisualUpdateOptions) {
-        this.eventService.renderingStarted(options)
+        this.eventService.renderingStarted(options);
         try {
             const dataView: DataView = this.dataView = options.dataViews && options.dataViews[0];
 
             if (!dataView?.metadata?.columns || !dataView?.categorical?.values) {
+                // TODO: render a landing page prompting to add "Top values" / "Bottom values" instead of a blank visual
                 this.displayRootElement(false);
+                this.eventService.renderingFinished(options);
                 return;
             }
 
@@ -528,7 +531,7 @@ export class DualKpi implements IVisual {
             if (wasDataSetRendered) {
                 this.drawBottomContainer(chartWidth, chartHeight, chartTitleSpace, chartSpaceBetween, iconOffset);
             }
-            this.eventService.renderingFinished(options)
+            this.eventService.renderingFinished(options);
         } catch (error) {
             this.eventService.renderingFailed(options, error);
             console.warn("Rendering error", error);
@@ -1180,9 +1183,14 @@ export class DualKpi implements IVisual {
             iconWidth = 16;
         }
 
+        // shift the title to the right when the warning icon is shown, so they don't overlap
+        const hasWarning: boolean = this.data.warningState < 0;
+        const titleStartX: number = hasWarning ? (iconWidth + 6) : 0;
+        chartTitleElement.attr("transform", "translate(" + titleStartX + ",0)");
+
         // add warning icon
-        if (this.data.warningState < 0) {
-            this.createWarningMessage(chartTitleElement, iconY, iconScaleTransform, iconWidth);
+        if (hasWarning) {
+            this.createWarningMessage(iconY, iconScaleTransform);
         }
 
         // add info icon
@@ -1210,7 +1218,7 @@ export class DualKpi implements IVisual {
             }
             dayRangeElement.attr("transform", "translate(" + (dayRangeLeft) + ",0)");
 
-            const titleMaxWidth = dayRangeLeft - dayRangeElement.node().getBBox().width;
+            const titleMaxWidth = dayRangeLeft - dayRangeElement.node().getBBox().width - titleStartX - DualKpi.BOTTOM_TITLE_GAP;
             this.tailorTextByMaxWidth(chartTitleElement, titleMaxWidth);
         }
 
@@ -1228,7 +1236,7 @@ export class DualKpi implements IVisual {
         text.text(tailoredText);
     }
 
-    private createWarningMessage(chartTitleElement, iconY: number, iconScaleTransform: string, iconWidth: number) {
+    private createWarningMessage(iconY: number, iconScaleTransform: string) {
         const warning = this.bottomContainer.warning;
         warning.group
             .attr("transform", "translate(0," + (iconY) + ")");
@@ -1251,9 +1259,6 @@ export class DualKpi implements IVisual {
                     value: this.data.settings.properties.tooltipGroup.warningTooltipText.value
                 }];
             });
-
-        // move title over to account for icon
-        chartTitleElement.attr("transform", "translate(" + (iconWidth + 6) + ",0)");
     }
 
     private createInfoMessage(iconY: number, iconScaleTransform: string, iconWidth: number, chartWidth: number, dataDaysOld: number) {
@@ -1488,9 +1493,14 @@ export class DualKpi implements IVisual {
             fontFamily: string = isTitle ? options.fontFamilyTitle : options.fontFamilyValue;
 
 
+        // Text elements are reused across renders, so stale styling must be cleared explicitly.
+        // Auto mode sizes via the CSS class; an inline font-size attribute would win over the class (SVG precedence),
+        // so clear it. Manual mode sets the inline size; drop the auto class so the two modes never mix.
         if (fontSizeAutoFormatting) {
             element.classed(this.sizeCssClass, true);
+            element.attr("font-size", null);
         } else {
+            element.classed(this.sizeCssClass, false);
             element.attr("font-size", fontSize);
         }
 
@@ -1498,16 +1508,6 @@ export class DualKpi implements IVisual {
         element.attr("font-style", isItalic ? "italic" : "normal");
         element.attr("text-decoration", isUnderline ? "underline" : "none");
         element.attr("font-family", fontFamily);
-
-        const effectiveFontSize = fontSizeAutoFormatting ? element.style("font-size") : fontSize + "px";
-        const tailoredText = textMeasurementService.getTailoredTextOrDefault({
-            text: element.text(),
-            fontSize: effectiveFontSize,
-            fontFamily: fontFamily,
-        }, options.width * DualKpi.VISUAL_BORDER_AREA_PADDING_RATIO);
-
-        element.text(tailoredText);
-
     }
 
     private addOverlayText(options: IDualKpiOptions, latestValue: number, calcHeight: number, calcWidth: number, isTopChart: boolean): void {
@@ -1563,6 +1563,7 @@ export class DualKpi implements IVisual {
             .text(options.showDefaultTextOverlay ? "" : options.chartTitle + " (" + percentChange + ")");
 
         this.applyTextStyle(dataTitle, options, true);
+        this.tailorTextByMaxWidth(dataTitle, options.width * DualKpi.VISUAL_BORDER_AREA_PADDING_RATIO);
 
         const dataValue = chartOverlay.text;
         dataValue
@@ -1623,8 +1624,11 @@ export class DualKpi implements IVisual {
         const { fontFamily, bold, italic, underline } = settings.titleGroup.font;
         const textColor = settings.titleGroup.textColor.value;
         element.attr("class", "title");
+        // Title element is reused across renders. In auto mode the size comes from the CSS class,
+        // so clear any inline font-size left by a previous manual render (inline attr overrides the class in SVG).
         if (settings.titleGroup.fontSizeAutoFormatting.value) {
             element.classed(this.sizeCssClass, true);
+            element.attr("font-size", null);
         } else {
             element.attr("font-size", settings.titleGroup.font.fontSize.value);
         }


### PR DESCRIPTION
fix(visual): complete rendering events, reset font size, fix title layout

- Call renderingFinished/renderingFailed on all update() paths (no-data included)
- Reset stale inline font-size when switching back to Auto text size
- Stop truncating KPI values with an ellipsis; tailor only the title
- Fix chart title overlapping the date range label
- Remove version number from visual display name
- Update CI workflows; rename npm 'eslint' script to 'lint'; bump to 2.2.3.0